### PR TITLE
Multi-stage build for smaller Docker image

### DIFF
--- a/Dockerfile_API
+++ b/Dockerfile_API
@@ -1,6 +1,12 @@
-FROM golang:1.23.4
+# Build stage
+FROM golang:1.23.4 AS build
 
 WORKDIR /app/api
+
+# CGO (C bindings for Go)
+# When CGO_ENABLED=0, Go builds a fully statically linked binary, meaning it does not rely on any external C libraries.
+# This ensures that the binary is self-contained and portable.
+ARG CGO_ENABLED=0
 
 COPY ./api .
 
@@ -10,8 +16,17 @@ RUN go mod download
 
 RUN go build -o main .
 
+# Run stage
+FROM alpine:latest
+
+WORKDIR /app/api
+
 ENV GIN_MODE=release
 ENV API_PORT=8080
 ENV TZ=UTC
+
+# Copy the compiled binary from the build stage
+COPY --from=build /app/api/main .
+COPY --from=build /app/defaults ../defaults
 
 CMD ["./main"]


### PR DESCRIPTION
I have not tested it, but this should work because `CGO_ENABLED=0` ensures the binary does not depend on external libraries